### PR TITLE
Implementing and using canLoad on the lazy modules

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -66,10 +66,10 @@ export const ROUTES: Routes = [
 			}
 	},
 
-	{ path: "tasks", loadChildren: "./pages/task/task.module#TaskModule" },
-	{ path: "users", loadChildren: "./pages/user/user.module#UserModule" },
-	{ path: "teams", loadChildren: "./pages/team/team.module#TeamModule" },
-	{ path: "projects", loadChildren: "./pages/project/project.module#ProjectModule" },
+	{ path: "tasks", loadChildren: "./pages/task/task.module#TaskModule", canLoad: [AuthGuard] },
+	{ path: "users", loadChildren: "./pages/user/user.module#UserModule", canLoad: [AuthGuard] },
+	{ path: "teams", loadChildren: "./pages/team/team.module#TeamModule", canLoad: [AuthGuard] },
+	{ path: "projects", loadChildren: "./pages/project/project.module#ProjectModule", canLoad: [AuthGuard] },
 
 	{
 		path: '**',

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,10 +1,18 @@
 import { SharedService } from 'src/app/core/services/shared.service';
-import { Router, RouterStateSnapshot, ActivatedRouteSnapshot, CanActivate } from '@angular/router';
+import {
+	Router,
+	RouterStateSnapshot,
+	ActivatedRouteSnapshot,
+	CanActivate,
+	CanLoad,
+	Route,
+	UrlSegment
+} from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 
 @Injectable()
-export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate, CanLoad {
 
 	constructor(
 		private router: Router,
@@ -17,5 +25,9 @@ export class AuthGuard implements CanActivate {
 		}
 		this.router.navigate(['/login'], {queryParams: {fromUrl: state.url}});
 		return false;
+	}
+
+	canLoad(route: Route, segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean {
+		return this.sharedService.isUserLoggedIn() || this.sharedService.isUserInLocalStorage();
 	}
 }


### PR DESCRIPTION
canLoad is used to prevent the application from loading entire modules lazily if the user is not authorized to do so.

So i used on the lazy modules to improve performance